### PR TITLE
add config options to show or not show language tags

### DIFF
--- a/frab/node.json
+++ b/frab/node.json
@@ -69,13 +69,13 @@
             "default": "primary"
         }]
     }, {
-		"title": "Show Language Tags", 
-		"name": "show_language_tags",
-		"type": "boolean",
-		"itemname": "show_language_tags",
-		"hint": "Show Language Tag at end of talk names", 
-		"default": true
-	}, {
+        "title": "Show Language Tags", 
+        "name": "show_language_tags",
+        "type": "boolean",
+        "itemname": "show_language_tags",
+        "hint": "Show Language Tag at end of talk names", 
+        "default": true
+    }, {
         "title": "Rooms",
         "name": "rooms",
         "doc_link": true,

--- a/frab/node.json
+++ b/frab/node.json
@@ -69,6 +69,13 @@
             "default": "primary"
         }]
     }, {
+		"title": "Show Language Tags", 
+		"name": "show_language_tags",
+		"type": "boolean",
+		"itemname": "show_language_tags",
+		"hint": "Show Language Tag at end of talk names", 
+		"default": true
+	}, {
         "title": "Rooms",
         "name": "rooms",
         "doc_link": true,

--- a/frab/tile.lua
+++ b/frab/tile.lua
@@ -30,7 +30,7 @@ util.data_mapper{
 function M.updated_config_json(config)
     font = resource.load_font(api.localized(config.font.asset_name))
     info_font = resource.load_font(api.localized(config.info_font.asset_name))
-	show_language_tags = config.show_language_tags
+    show_language_tags = config.show_language_tags
 
     rooms = {}
     for idx, room in ipairs(config.rooms) do
@@ -79,11 +79,11 @@ function M.updated_schedule_json(new_schedule)
             table.remove(schedule, idx)
         else
             if talk.lang ~= "" then
-				if show_language_tags then
-                	talk.title = talk.title .. " (" .. talk.lang .. ")"
-				else
-                	talk.title = talk.title
-				end
+                if show_language_tags then
+                    talk.title = talk.title .. " (" .. talk.lang .. ")"
+                else
+                    talk.title = talk.title
+                end
             end
 
             talk.track = tracks[talk.track] or {

--- a/frab/tile.lua
+++ b/frab/tile.lua
@@ -17,6 +17,7 @@ local current_talk
 local other_talks = {}
 local last_check_min = 0
 local day = 0
+local show_language_tags = true
 
 local M = {}
 
@@ -29,6 +30,7 @@ util.data_mapper{
 function M.updated_config_json(config)
     font = resource.load_font(api.localized(config.font.asset_name))
     info_font = resource.load_font(api.localized(config.info_font.asset_name))
+	show_language_tags = config.show_language_tags
 
     rooms = {}
     for idx, room in ipairs(config.rooms) do
@@ -77,7 +79,11 @@ function M.updated_schedule_json(new_schedule)
             table.remove(schedule, idx)
         else
             if talk.lang ~= "" then
-                talk.title = talk.title .. " (" .. talk.lang .. ")"
+				if show_language_tags then
+                	talk.title = talk.title .. " (" .. talk.lang .. ")"
+				else
+                	talk.title = talk.title
+				end
             end
 
             talk.track = tracks[talk.track] or {


### PR DESCRIPTION
Some Conferences don't know how to write a correct schedule.xml. This PR adds a checkbox to enable or disable rendering of a language tag like "(de)" or "(en)" at the end of every talk if you don't want to show them.